### PR TITLE
fixes darkmode selection persistence after refresh or page change

### DIFF
--- a/assets/js/logic.js
+++ b/assets/js/logic.js
@@ -1,26 +1,46 @@
-let darkmode = localStorage.getItem('darkmode');
 let icon = document.getElementById("dark-mode-toggle");
 
-if(localStorage.getItem('darkmode' == 'enabled')) {
-    document.body.classList.add('dark-mode');
-}
+/**
+ * Handles the page load event.
+ */
+const handlePageLoad = function () {
+  // Retrieve the dark mode status from local storage
+  const darkStatus = localStorage.getItem("darkmode");
+  console.log("darkStatus", darkStatus);
 
-icon.addEventListener('click', function(event) {
-    document.body.classList.toggle('dark-mode');
+  // Check if dark mode is enabled
+  if (darkStatus == "true") {
+    // Update the icon and apply the dark mode class to the body
+    icon.innerHTML = "🌒";
+    document.body.classList.add("dark-mode");
+    console.log("dark mode", "enabled", darkStatus);
+  } else {
+    // Update the icon to indicate that dark mode is disabled
+    icon.innerHTML = "🌕";
+    console.log("dark mode", "disabled", darkStatus);
+  }
+};
 
-    if (document.body.classList.contains('dark-mode')){
-        
-        icon.innerHTML = '🌒';
-        localStorage.setItem('darkmode', 'enabled')
-    
-        console.log(darkmode, "Enabled");
-    }
-    else {
-        icon.innerHTML = '🌕';
-        localStorage.setItem('darkmode', null);
+/**
+ * Handles the click event for the toggle button.
+ */
+const handleToggleClick = function () {
+  // Toggles the "dark-mode" class on the document body and returns a boolean indicating if the class was added or removed.
+  const toggle = document.body.classList.toggle("dark-mode");
+  console.log("toggle", toggle);
 
-        console.log(darkmode, "Disabled");
-    }
-});
+  // Updates the icon and stores the dark mode state in the local storage based on the toggle value.
+  if (toggle) {
+    icon.innerHTML = "🌒";
+    localStorage.setItem("darkmode", true);
+    console.log("Dark Mode Enabled");
+  } else {
+    icon.innerHTML = "🌕";
+    localStorage.setItem("darkmode", false);
+    console.log("Dark Mode Disabled");
+  }
+};
 
+icon.addEventListener("click", handleToggleClick);
 
+window.addEventListener("load", handlePageLoad);


### PR DESCRIPTION
I created 2 functions to handle situations where either the toggle is clicked or the page reloads because of a refresh or because site navigation from index.html to blog.html has occurred or vis versa.  

**Take a look at these changes and see if you have any questions for me! Feel free to merge the pull request, or simply look at the code I changed and then work on editing your own without pulling in these changes.**  